### PR TITLE
fix: Recover immediate terminal for child #2

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@
 #    By: minjungk <minjungk@student.42seoul.kr>     +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/01/24 23:09:45 by minjungk          #+#    #+#              #
-#    Updated: 2023/02/03 07:17:11 by minjungk         ###   ########.fr        #
+#    Updated: 2023/02/06 03:44:30 by minjungk         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -14,6 +14,8 @@
 .DEFAULT_GOAL := all
 
 CFLAGS		= -Wall -Wextra -Werror -MMD -MP -O3
+
+CPPFLAGS	+= -I./prompt
 
 CPPFLAGS	+= -I../lib/libft
 LDFLAGS		+= -L../lib/libft
@@ -29,6 +31,7 @@ MINISHELL_SRCS = \
 	minishell.c \
 	util/ft_debug.c \
 	util/ft_assert.c \
+	prompt/prompt.c \
 	builtin/pwd.c \
 
 MINISHELL_OBJS := $(MINISHELL_SRCS:.c=.o)

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,69 +6,25 @@
 /*   By: minjungk <minjungk@student.42seoul.>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/24 23:20:36 by minjungk          #+#    #+#             */
-/*   Updated: 2023/02/04 23:46:41 by minjungk         ###   ########.fr       */
+/*   Updated: 2023/02/06 03:48:17 by minjungk         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+#include "prompt.h"
 
-static volatile sig_atomic_t	g_status;
-
-static void	handler(int sig)
+int	main(void)
 {
-	g_status = sig;
-}
-
-static int	event(void)
-{
-	if (g_status == SIGINT)
-	{
-		write(STDOUT_FILENO, "\n", 1);
-		rl_replace_line("", 1);
-		rl_on_new_line();
-		rl_redisplay();
-		g_status = 0;
-	}
-	return (0);
-}
-
-static void	loop(void)
-{
-	char	*line;
 	char	*command;
 
 	while (1)
 	{
-		line = readline("minishell$ ");
-		if (line == NULL)
-		{
-			ft_putstr_fd("exit\n", STDOUT_FILENO);
-			break ;
-		}
-		command = ft_strtrim(line, " ");
-		if (command && *command)
-		{
-			add_history(command);
-			printf("[TODO] execute[%s]\n", command);
-		}
+		command = prompt();
+		if (command == NULL)
+			continue ;
+		printf("[TODO] execute[%s]\n", command);
 		free(command);
-		free(line);
 	}
 	rl_clear_history();
-}
-
-int	main(void)
-{
-	struct termios	term_org;
-	struct termios	term_new;
-
-	rl_event_hook = event;
-	signal(SIGINT, handler);
-	tcgetattr(STDIN_FILENO, &term_org);
-	tcgetattr(STDIN_FILENO, &term_new);
-	term_new.c_cc[VQUIT] = 0;
-	tcsetattr(STDIN_FILENO, TCSANOW, &term_new);
-	loop();
-	tcsetattr(STDIN_FILENO, TCSANOW, &term_org);
 	exit(EXIT_SUCCESS);
 }

--- a/src/prompt/prompt.c
+++ b/src/prompt/prompt.c
@@ -1,0 +1,79 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   prompt.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: minjungk <minjungk@student.42seoul.kr>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/02/06 02:10:21 by minjungk          #+#    #+#             */
+/*   Updated: 2023/02/06 03:43:18 by minjungk         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "prompt.h"
+
+static volatile sig_atomic_t	g_status;
+
+static void	handler(int sig)
+{
+	g_status = sig;
+}
+
+static int	event(void)
+{
+	if (g_status == SIGINT)
+	{
+		write(STDOUT_FILENO, "\n", 1);
+		rl_replace_line("", 1);
+		rl_on_new_line();
+		rl_redisplay();
+		g_status = 0;
+	}
+	return (0);
+}
+
+static void	set_terminal(void)
+{
+	struct termios	term;
+
+	rl_event_hook = event;
+	tcgetattr(STDIN_FILENO, &term);
+	term.c_cc[VQUIT] = 0;
+	tcsetattr(STDIN_FILENO, TCSANOW, &term);
+}
+
+static char	*get_readline(void)
+{
+	struct termios	term;
+	char			*line;
+
+	signal(SIGINT, handler);
+	signal(SIGQUIT, handler);
+	tcgetattr(STDIN_FILENO, &term);
+	set_terminal();
+	line = readline("minishell$ ");
+	tcsetattr(STDIN_FILENO, TCSANOW, &term);
+	return (line);
+}
+
+char	*prompt(void)
+{
+	char	*line;
+	char	*command;
+
+	line = get_readline();
+	if (line == NULL)
+	{
+		ft_putstr_fd("exit\n", STDOUT_FILENO);
+		exit(EXIT_SUCCESS);
+	}
+	command = ft_strtrim(line, " ");
+	if (command == NULL || *command == '\0')
+	{
+		free(command);
+		return (NULL);
+	}
+	add_history(command);
+	free(line);
+	return (command);
+}

--- a/src/prompt/prompt.h
+++ b/src/prompt/prompt.h
@@ -1,19 +1,23 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   minishell.h                                        :+:      :+:    :+:   */
+/*   prompt.h                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: minjungk <minjungk@student.42seoul.>       +#+  +:+       +#+        */
+/*   By: minjungk <minjungk@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2023/01/24 23:20:48 by minjungk          #+#    #+#             */
-/*   Updated: 2023/02/06 02:08:43 by minjungk         ###   ########.fr       */
+/*   Created: 2023/02/06 02:07:45 by minjungk          #+#    #+#             */
+/*   Updated: 2023/02/06 02:42:07 by minjungk         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef MINISHELL_H
-# define MINISHELL_H
-# include <stdio.h>
-# include <stdlib.h>
+#ifndef PROMPT_H
+# define PROMPT_H
+# include <signal.h>
+# include <termios.h>
+# include <readline/history.h>
+# include <readline/readline.h>
 # include "libft.h"
+
+extern char	*prompt(void);
 
 #endif


### PR DESCRIPTION
- minishell 헤더에서 readline 관련 의존성 분리
- 자식 프로세스 때문에 readline이 끝난 후 터미널 설정을 즉시 복구하도록 수정