### PR TITLE
fix: check redirect-filename pair after expand env

### DIFF
--- a/src/execute/redirect.c
+++ b/src/execute/redirect.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   redirect.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: minjungk <minjungk@student.42seoul.kr>     +#+  +:+       +#+        */
+/*   By: jaemjeon <jaemjeon@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/18 21:12:10 by minjungk          #+#    #+#             */
-/*   Updated: 2023/05/18 23:24:17 by minjungk         ###   ########.fr       */
+/*   Updated: 2023/05/19 17:29:29 by jaemjeon         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,7 +42,7 @@ t_redirect	*new_redirect(t_env **table, t_e_lex type, char *file)
 	content->type = type;
 	content->filename = file;
 	content->fd = -1;
-	if (type == LEXEME_HEREDOC)
+	if (type == LEXEME_HEREDOC && file[0] != '\0')
 		content->fd = get_heredoc(table, file);
 	content->flag = O_RDONLY;
 	if (type == LEXEME_OUTFILE)

--- a/src/execute/set_pipex.c
+++ b/src/execute/set_pipex.c
@@ -6,7 +6,7 @@
 /*   By: jaemjeon <jaemjeon@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/12 20:40:50 by minjungk          #+#    #+#             */
-/*   Updated: 2023/05/19 02:18:50 by minjungk         ###   ########.fr       */
+/*   Updated: 2023/05/19 17:27:23 by jaemjeon         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,13 +23,16 @@ static t_lex_lst	*_redirect(
 
 	if (curr == NULL)
 		return (NULL);
+	file = NULL;
 	curr = skip_lexeme_ifs(curr->next);
 	if (curr == NULL)
-		return (NULL);
-	file = NULL;
-	curr = combine_string(pipex->envp, curr, &file);
-	if (file == NULL)
-		return (NULL);
+		file = ft_strdup("");
+	else
+	{
+		curr = combine_string(pipex->envp, curr, &file);
+		if (file == NULL)
+			return (NULL);
+	}
 	tmp = new_redirect(pipex->envp, type, file);
 	if (tmp == NULL)
 	{


### PR DESCRIPTION
# as-is

```
minishell$ ls > $A
Makefile
minishell.c
...
...

minishell$ export A=a
minishell$ ls > a$A (file 'aa' created)
minishell$ ls > >
: ambiguous redirect

minishell$ ls <<
Makefile
minishell.c
...
...

minishrll$ ls > a < (file 'a' created)
```

# be-to

```
minishell$ ls > $A
: ambiguous redirect

minishell$ export A=a
minishell$ ls > a$A (file 'aa' created)

minishell$ ls > >
: ambiguous redirect

minishell$ ls <<
: ambiguous redirect (don't read heredoc)

minishrll$ ls > a <
: ambiguous redirect (file 'a' created)

```