### PR TITLE
fix/exit_status logic#77

### DIFF
--- a/src/environ/environ.h
+++ b/src/environ/environ.h
@@ -3,17 +3,19 @@
 /*                                                        :::      ::::::::   */
 /*   environ.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: minjungk <minjungk@student.42seoul.kr>     +#+  +:+       +#+        */
+/*   By: jaemjeon <jaemjeon@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/02/24 12:11:44 by minjungk          #+#    #+#             */
-/*   Updated: 2023/04/19 22:34:11 by minjungk         ###   ########.fr       */
+/*   Updated: 2023/05/21 11:37:53 by jaemjeon         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
+
 #ifndef ENVIRON_H
 # define ENVIRON_H
 # include "util.h"
 
-# define ENVIRON_HASH_MAX	62
+# define ENVIRON_HASH_MAX			62
+# define SYNTAX_ERROR_EXIT_STATUS	258
 
 typedef t_list	t_env;
 

--- a/src/execute/executor.c
+++ b/src/execute/executor.c
@@ -6,7 +6,7 @@
 /*   By: jaemjeon <jaemjeon@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/05 15:12:55 by minjungk          #+#    #+#             */
-/*   Updated: 2023/05/21 00:03:29 by minjungk         ###   ########.fr       */
+/*   Updated: 2023/05/21 11:35:23 by jaemjeon         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,7 +75,6 @@ static int	_pipe(t_env **table, t_parse *tree)
 
 int	execute(t_env **table, t_parse *tree)
 {
-	char			*tmp;
 	int				status;
 	t_pipex			*pipex;
 
@@ -95,8 +94,5 @@ int	execute(t_env **table, t_parse *tree)
 		status = all_pipex(pipex);
 		ft_lstdelone(pipex, free_pipex);
 	}
-	tmp = ft_itoa(status);
-	env_set(table, "?", tmp);
-	free(tmp);
 	return (status);
 }

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: jaemjeon <jaemjeon@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/24 23:20:36 by minjungk          #+#    #+#             */
-/*   Updated: 2023/05/21 01:04:14 by minjungk         ###   ########.fr       */
+/*   Updated: 2023/05/21 11:48:47 by jaemjeon         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,16 +22,13 @@ static int	run(t_env **table, char *command)
 	t_lex_lst	*tokens;
 	t_parse		*parse_tree;
 
-	exit_status = EXIT_FAILURE;
+	exit_status = SYNTAX_ERROR_EXIT_STATUS;
 	tokens = lex(command);
 	if (tokens)
 	{
 		parse_tree = parse(tokens);
 		if (parse_tree == NULL || is_syntax_error(parse_tree))
-		{
-			env_set(table, "?", "258");
 			ft_putstr_fd("minishell: syntax error\n", 2);
-		}
 		else
 			exit_status = execute(table, parse_tree);
 		clear_parse_tree(parse_tree, free);
@@ -45,6 +42,7 @@ int	main(void)
 {
 	char	*command;
 	t_env	**table;
+	char	*str_exit_status;
 
 	table = env_load();
 	ft_assert(table == NULL, __FILE__, __LINE__);
@@ -53,7 +51,9 @@ int	main(void)
 		command = prompt();
 		if (command == NULL)
 			continue ;
-		run(table, command);
+		str_exit_status = ft_itoa(run(table, command));
+		env_set(table, "?", str_exit_status);
+		free(str_exit_status);
 		free(command);
 	}
 	env_clear(&table);


### PR DESCRIPTION
#  lexing error exit_status
# as-is

```
minishell$ '
minishell: lexing error
echo $?
0
minishell$ "
minishell: syntax error
minishell$ echo $?
258
```

# be-to
```
minishell$ '
minishell: lexing error
minishell$ echo $?
258
minishell$ "
minishell: syntax error
minishell$ echo $?
258
```

#  setting execute exit_status
# as-is

set exit_status in executor function

# bo-to

executor function only return int exit_status
and set env in function main function
