### PR TITLE
Enhance/no builtin#87

### DIFF
--- a/src/builtin/builtin.c
+++ b/src/builtin/builtin.c
@@ -3,14 +3,16 @@
 /*                                                        :::      ::::::::   */
 /*   builtin.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: minjungk <minjungk@student.42seoul.kr>     +#+  +:+       +#+        */
+/*   By: jaemjeon <jaemjeon@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/02/08 22:32:56 by minjungk          #+#    #+#             */
-/*   Updated: 2023/05/22 00:07:31 by minjungk         ###   ########.fr       */
+/*   Updated: 2023/05/22 10:54:15 by jaemjeon         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtin.h"
+#include "sys/stat.h"
+#include <errno.h>
 
 extern int	builtin_pwd(void);
 extern int	builtin_cd(t_env **table, int argc, char **argv);
@@ -20,32 +22,56 @@ extern int	builtin_export(t_env **table, int argc, char **argv);
 extern int	builtin_unset(t_env **table, int argc, char **argv);
 extern int	builtin_env(t_env **table, int argc, char **argv);
 
+static char	*strjoin3(char *s1, char *s2, char *s3)
+{
+	char	*rtn;
+	char	*tmp;
+
+	rtn = ft_strjoin(s1, s2);
+	tmp = rtn;
+	rtn = ft_strjoin(tmp, s3);
+	free(tmp);
+	return (rtn);
+}
+
+static void	search_path(t_env **table, char **argv, char **envp)
+{
+	int			i;
+	char		**sp;
+	char		*execve_path;
+	struct stat	st;
+
+	sp = ft_split(env_get_val(table, "PATH"), ':');
+	i = 0;
+	while (sp && sp[i])
+	{
+		execve_path = strjoin3(sp[i], "/", argv[0]);
+		if (stat(execve_path, &st) == 0)
+			exit(execve(execve_path, argv, envp));
+		free(sp[i++]);
+	}
+}
+
 static int	no_builtin(t_env **table, char **argv)
 {
-	int		i;
-	pid_t	pid;
-	char	**sp;
-	char	**envp;
-	char	command[PATH_MAX];
+	pid_t		pid;
+	char		**envp;
+	struct stat	st;
 
 	pid = fork();
 	if (pid)
 		return (waitpid_ignore_signal(pid));
 	envp = env_get_arr(table);
-	execve(argv[0], argv, envp);
-	i = 0;
-	sp = ft_split(env_get_val(table, "PATH"), ':');
-	while (sp && sp[i])
+	if (ft_strchr(argv[0], '/') != NULL)
 	{
-		ft_strlcpy(command, sp[i], PATH_MAX);
-		ft_strlcat(command, "/", PATH_MAX);
-		ft_strlcat(command, argv[0], PATH_MAX);
-		execve(command, argv, envp);
-		free(sp[i++]);
+		if (stat(argv[0], &st) == 0)
+			execve(argv[0], argv, envp);
 	}
-	free(sp);
-	ft_putstr_fd(argv[0], STDERR_FILENO);
-	ft_putstr_fd(": command not found\n", STDERR_FILENO);
+	else
+		search_path(table, argv, envp);
+	perror(argv[0]);
+	if (errno == EISDIR || errno == EACCES)
+		exit(126);
 	exit(127);
 }
 

--- a/src/builtin/cd.c
+++ b/src/builtin/cd.c
@@ -6,7 +6,7 @@
 /*   By: minjungk <minjungk@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/02/08 23:08:02 by minjungk          #+#    #+#             */
-/*   Updated: 2023/05/21 23:50:01 by minjungk         ###   ########.fr       */
+/*   Updated: 2023/05/22 15:48:05 by minjungk         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,10 +57,8 @@ static int	_cd(t_env **table, char *path)
 	char		oldpath[PATH_MAX];
 	char		currpath[PATH_MAX];
 
-	if (path == NULL)
-		path = env_get_val(table, "HOME");
 	if (path == NULL || *path == '\0')
-		return (EXIT_FAILURE);
+		return (EXIT_SUCCESS);
 	getcwd(oldpath, PATH_MAX);
 	ft_memset(currpath, 0, PATH_MAX);
 	if (*path == '/'
@@ -98,7 +96,7 @@ int	builtin_cd(t_env **table, int argc, char **argv)
 	path = env_get_val(table, key);
 	if (path)
 		return (_cd(table, path));
-	ft_putstr_fd("minishell: cd: \n", STDERR_FILENO);
+	ft_putstr_fd("minishell: cd: ", STDERR_FILENO);
 	ft_putstr_fd(key, STDERR_FILENO);
 	ft_putstr_fd(" not set\n", STDERR_FILENO);
 	return (EXIT_FAILURE);

--- a/src/execute/executor.c
+++ b/src/execute/executor.c
@@ -6,7 +6,7 @@
 /*   By: jaemjeon <jaemjeon@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/05 15:12:55 by minjungk          #+#    #+#             */
-/*   Updated: 2023/05/22 02:01:18 by minjungk         ###   ########.fr       */
+/*   Updated: 2023/05/22 15:40:45 by minjungk         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -82,7 +82,7 @@ int	execute(t_env **table, t_parse *tree, int is_first)
 {
 	int				status;
 	t_pipex			*pipex;
-	char			**argv;
+	struct s_pipex	*content;
 
 	if (tree == NULL)
 		return (EXIT_SUCCESS);
@@ -97,8 +97,9 @@ int	execute(t_env **table, t_parse *tree, int is_first)
 	pipex = new_pipex(table, tree);
 	if (is_first && pipex && pipex->content)
 	{
-		argv = ((struct s_pipex *)(pipex->content))->argv;
-		if (argv && argv[0] && ft_strncmp(argv[0], "exit", 5) == 0)
+		content = pipex->content;
+		if (content->argc == 2 && content->argv && content->argv[0]
+			&& ft_strncmp(content->argv[0], "exit", 5) == 0)
 			ft_putstr_fd("exit\n", STDERR_FILENO);
 	}
 	status = all_pipex(pipex);


### PR DESCRIPTION
fix: edit no_builtin command logic

# as-is

./ls 실행시 /bin/ls가 실행됨

# be-to

1. check path_cmd or general_cmd

(path_cmd)

2-1 : check file is there

2-2(found file) : execve!

2-3(file not found || execve fail) : print error && exit correct exit_status



(general_cmd)

2-1 : loop path and check file is there.

2-2(find file) : execve! if execve failed exit 0

2-3-1(found file) : try execve, if failed exit 255

2-3-2(file not found) : print error && exit 126 || exit 127
